### PR TITLE
Deck.draw() bugfix

### DIFF
--- a/lib/cards.js
+++ b/lib/cards.js
@@ -192,16 +192,16 @@ Deck.prototype.draw = function(count, _into) {
 		throw new RangeError('Cannot draw card from deck; No cards remaining.');
 	}
 	
-	if (typeof count === 'number') {
-		var cards = [ ];
-		for (var i = 0; i < count; i++) {
-			cards.push(self.draw());
-		}
-		return cards;
+	if (!count){
+		return this.deck.shiftInto(_into || this.held);
 	}
 	
-	_into = _into || this.held
-	return this.deck.shiftInto(_into);
+	var cards = [ ];
+	for (var i = 0; i < count; i++){	
+		cards.push(self.draw(0, _into));
+	}
+	
+	return cards;
 };
 
 /**


### PR DESCRIPTION
The recursive nature of Deck.draw() is intriguing, but was dropping
the _into parameter. Now it no longer defaults to the Held pile every time
and I preserved the recursive structure.

This also meant that the Deck.drawToDiscard() function never even worked.

Had fun reading this file, just learning js.
