### PR TITLE
Fixed syntax error

### DIFF
--- a/lib/cards.js
+++ b/lib/cards.js
@@ -70,7 +70,7 @@ Card.suitUnicodeStrings = {
 	club:     '♣',
 	spade:    '♠',
 	sword:    '☨',
-	coin      '⚪',
+	coin:     '⚪',
 	cup:      '☕'
 };
 


### PR DESCRIPTION
There was a syntax error in lib/cards.js in the to_unicode function
