### PR TITLE
Add source formatting. Serves as beginning of style guide.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,8 +2,7 @@
 
 #
 # Formatting configuration for those that may choose to not use prettier.
-# At least serves as documentation for how code contributions should be
-# formatted.
+# At least serves as a minimal styleguide for contributors.
 #
 
 root = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# editorconfig.org
+
+#
+# Formatting configuration for those that may choose to not use prettier.
+# At least serves as documentation for how code contributions should be
+# formatted.
+#
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 2
+max_line_length = 80
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.bat]
+end_of_line = crlf
+
+[Makefile]
+indent_style = tab

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,6 @@ docs
 tests
 src
 .github
+.prettier*
+.editorconfig
+tsconfig.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Yes. Format these files when they are present.
+!.prettier*/
+!.mochar*/
+!.huskyr*/
+
+# No. Do not format these files.
+.github
+/docs
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@
 .github
 /docs
 node_modules/
+/build

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,34 @@
+/** Simple logger. */
+/* istanbul ignore next: Unnecessary. */
+if (!global.log) global.log = console;
+
+/** Formatter configuration. */
+const config = {
+	arrowParens: 'always',
+	bracketSpacing: true,
+	endOfLine: 'lf',
+	printWidth: 80,
+	proseWrap: 'never',
+	quoteProps: 'as-needed',
+	semi: true,
+	singleQuote: true,
+	tabWidth: 2,
+	trailingComma: 'all',
+	useTabs: true,
+	overrides: [
+		{
+			files: ['**/*.json', '**/*.yaml', '**/*.yml'],
+			options: {
+				useTabs: false,
+			},
+		},
+	],
+};
+
+if (typeof require !== 'undefined' && require.main === module) {
+	// When a script.
+	log.debug(JSON.stringify(config, null, 2));
+} else {
+	// When a module.
+	module.exports = config;
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,7 +2,7 @@
 /* istanbul ignore next: Unnecessary. */
 if (!global.log) global.log = console;
 
-/** Formatter configuration. */
+/** prettier formatter configuration. */
 const config = {
 	arrowParens: 'always',
 	bracketSpacing: true,

--- a/contributing.md
+++ b/contributing.md
@@ -18,6 +18,7 @@ Please manage your expectations accordingly.
 Pull Requests are welcome, given the following:
 
 - Attempt to generally follow the same coding style that already exists in the library. I don't have a styleguide or linter setup at the moment, and I don't really want to have to police such things if I don't have to; Please don't make me.
+- See `.editorconfig` and `.prettierrc.js` for minimal style guidance.
 - There is CI running in GitHub Actions; Please make sure that all builds succeed and pass all existing tests.
 - On the point of tests: there aren't very many at the moment, so I won't say its a requirement to add new tests if you add new code, but I also won't stop you...
 - Please don't make unneccesary breaking changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -914,10 +914,9 @@
     },
     "node_modules/prettier": {
       "version": "2.7.1",
-      "resolved": "https://registry.aws.itential.com/repository/itential/prettier/-/prettier-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -2004,7 +2003,7 @@
     },
     "prettier": {
       "version": "2.7.1",
-      "resolved": "https://registry.aws.itential.com/repository/itential/prettier/-/prettier-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/node": "^17.0.21",
         "chai": "^4.3.6",
         "mocha": "^9.2.2",
+        "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.5.19",
         "ts-node": "^10.7.0",
@@ -909,6 +910,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.aws.itential.com/repository/itential/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/randombytes": {
@@ -1983,6 +2000,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.aws.itential.com/repository/itential/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "randombytes": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "mocha --require ts-node/register ./tests/**/*.test.ts",
     "clean": "rimraf ./build ./docs",
     "docs": "typedoc --out docs src/index.ts",
-    "build": "tsc --build tsconfig.json"
+    "build": "tsc --build tsconfig.json",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "repository": {
     "type": "git",
@@ -27,6 +29,7 @@
     "@types/node": "^17.0.21",
     "chai": "^4.3.6",
     "mocha": "^9.2.2",
+    "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.7.0",


### PR DESCRIPTION
Add source formatting tools and configuration. Even if they are not used by all contributors, they may serve well as a minimal style guide.

- No actual formatting done at this time. Maybe later and after these tools and config are accepted.
- Not a linting/code analysis solution, just formatting.
- Not plugged in to CI or hooks. Maybe later.

Testing.

```shell
npm run format:check
# See exit code 1, fail.
echo "$?"

# Make all the formatting changes (don't commit if you don't intend to keep them!)
npm run format
```